### PR TITLE
docs: use pnpm run plugins install in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Perform tasks when you hit saved revision.
 ```
 
 ## Installation
-1. Install using http://%youretherpad%/admin/plugins or ``npm install ep_git_commit_saved_revision``
+1. Install using http://%youretherpad%/admin/plugins or ``pnpm run plugins install ep_git_commit_saved_revision``
 1. Copy / paste above settings example into the bottom of settings.json
 
 ## TODO


### PR DESCRIPTION
## Summary
Etherpad uses pnpm internally. The canonical install command per [etherpad-lite/doc/plugins.md](https://github.com/ether/etherpad-lite/blob/develop/doc/plugins.md) is `pnpm run plugins install ep_<name>`, not `npm install`. Update README to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)