### PR TITLE
fix: backward-compat for ESM etherpad

### DIFF
--- a/eejs.js
+++ b/eejs.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const eejs = require('ep_etherpad-lite/node/eejs/');
+const eejs = require('ep_etherpad-lite/node/eejs');
 
 exports.eejsBlock_body = (hookName, args, cb) => {
   args.content += eejs.require('ep_git_commit_saved_revision/templates/modals.ejs');

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ep_git_commit_saved_revision",
   "description": "Hooks on Saved Revision calls, designed to git commit a pad text when a user clicks Saved Revision Star",
-  "version": "11.0.24",
+  "version": "11.0.25",
   "author": "johnyma22 (John McLear) <john@mclear.co.uk>",
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
This PR makes the plugin backward-compatible with the upcoming ESM etherpad branch (ether/etherpad#7605).

**Change:** Remove trailing slash from `require("ep_etherpad-lite/node/eejs/")` → `require("ep_etherpad-lite/node/eejs")`

The trailing-slash form breaks under Node's strict ESM exports map resolution. This change is **backward-compatible** with the current CJS etherpad release.